### PR TITLE
Add configurable timer overlay browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# In-Browser Timer Extension
+
+A simple browser extension that injects a configurable timer at the top of every page. You can pick between 1, 2, 3 or 5 minutes, start/stop/reset the countdown and the timer changes color from green to yellow to red as time runs out. When the timer expires it keeps counting negatively and displays the message `please come to an end`.
+
+## Installation (Chromium browsers)
+
+1. Clone or download this repository.
+2. Open `chrome://extensions` in the browser.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select the folder of this project.
+5. Navigate to any page to see the timer.
+
+## Usage
+
+- Pick a duration from the dropdown and press **Start**.
+- **Stop** pauses the timer, **Reset** returns to the chosen duration.
+- The background color indicates remaining time:
+  - Green: 50–100%
+  - Yellow: 20–50%
+  - Red: 0–20% (and when over time)
+- After the countdown passes zero it goes negative and displays *please come to an end*.
+
+The extension does not require any special permissions and runs as a content script on all pages.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "In-Browser Timer",
+  "version": "1.0",
+  "description": "Adds a configurable timer overlay to every page.",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["timer.js"],
+      "css": ["timer.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/timer.css
+++ b/timer.css
@@ -1,0 +1,48 @@
+#in-browser-timer {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #2ecc71;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  font-family: sans-serif;
+  z-index: 2147483647;
+  text-align: center;
+}
+
+#in-browser-timer .ibt-display {
+  font-size: 1.5em;
+  margin-bottom: 5px;
+}
+
+#in-browser-timer .ibt-controls {
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  margin-bottom: 5px;
+}
+
+#in-browser-timer select,
+#in-browser-timer button {
+  padding: 3px 6px;
+  border: none;
+  border-radius: 4px;
+}
+
+#in-browser-timer button {
+  cursor: pointer;
+  background-color: #34495e;
+  color: #fff;
+}
+
+#in-browser-timer button:hover {
+  opacity: 0.85;
+}
+
+#in-browser-timer .ibt-message {
+  font-size: 0.9em;
+  font-weight: bold;
+}

--- a/timer.js
+++ b/timer.js
@@ -1,0 +1,110 @@
+(function() {
+  const existing = document.getElementById('in-browser-timer');
+  if (existing) return; // avoid injecting multiple times
+
+  const container = document.createElement('div');
+  container.id = 'in-browser-timer';
+
+  // timer display
+  const display = document.createElement('div');
+  display.className = 'ibt-display';
+  display.textContent = '00:00';
+
+  // controls
+  const controls = document.createElement('div');
+  controls.className = 'ibt-controls';
+
+  const select = document.createElement('select');
+  [1,2,3,5].forEach(min => {
+    const opt = document.createElement('option');
+    opt.value = min * 60; // seconds
+    opt.textContent = `${min} min`;
+    select.appendChild(opt);
+  });
+
+  const startBtn = document.createElement('button');
+  startBtn.textContent = 'Start';
+
+  const stopBtn = document.createElement('button');
+  stopBtn.textContent = 'Stop';
+
+  const resetBtn = document.createElement('button');
+  resetBtn.textContent = 'Reset';
+
+  controls.appendChild(select);
+  controls.appendChild(startBtn);
+  controls.appendChild(stopBtn);
+  controls.appendChild(resetBtn);
+
+  const message = document.createElement('div');
+  message.className = 'ibt-message';
+
+  container.appendChild(display);
+  container.appendChild(controls);
+  container.appendChild(message);
+  document.body.appendChild(container);
+
+  let duration = parseInt(select.value, 10);
+  let remaining = duration;
+  let interval = null;
+
+  function format(sec) {
+    const s = Math.abs(sec);
+    const m = Math.floor(s / 60).toString().padStart(2, '0');
+    const r = (s % 60).toString().padStart(2, '0');
+    return `${sec < 0 ? '-' : ''}${m}:${r}`;
+  }
+
+  function updateColor() {
+    const pct = (remaining / duration) * 100;
+    if (pct > 50) {
+      container.style.backgroundColor = '#2ecc71'; // green
+    } else if (pct > 20) {
+      container.style.backgroundColor = '#f1c40f'; // yellow
+    } else {
+      container.style.backgroundColor = '#e74c3c'; // red
+    }
+  }
+
+  function update() {
+    display.textContent = format(remaining);
+    if (remaining < 0) {
+      message.textContent = 'please come to an end';
+    } else {
+      message.textContent = '';
+    }
+    updateColor();
+  }
+
+  function tick() {
+    remaining -= 1;
+    update();
+  }
+
+  select.addEventListener('change', () => {
+    duration = parseInt(select.value, 10);
+    remaining = duration;
+    update();
+  });
+
+  startBtn.addEventListener('click', () => {
+    if (interval) return;
+    interval = setInterval(tick, 1000);
+  });
+
+  stopBtn.addEventListener('click', () => {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  });
+
+  resetBtn.addEventListener('click', () => {
+    clearInterval(interval);
+    interval = null;
+    remaining = duration;
+    update();
+  });
+
+  update();
+})();


### PR DESCRIPTION
## Summary
- add manifest and content scripts for an in-page timer
- implement timer controls with color change and negative overrun message
- style timer overlay and document installation/usage

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f907a2db08324a4ce2b7e24116d2a