### PR TITLE
Integrate timer with DOM and add popup toggle

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,10 @@
   "name": "In-Browser Timer",
   "version": "1.0",
   "description": "Adds a configurable timer overlay to every page.",
+  "permissions": ["storage", "tabs"],
+  "action": {
+    "default_popup": "popup.html"
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <button id="show">Show Timer</button>
+  <button id="hide">Hide Timer</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,17 @@
+function send(action) {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (tabs[0]) {
+      chrome.tabs.sendMessage(tabs[0].id, { action });
+    }
+  });
+}
+
+document.getElementById('show').addEventListener('click', () => {
+  chrome.storage.local.set({ timerVisible: true });
+  send('showTimer');
+});
+
+document.getElementById('hide').addEventListener('click', () => {
+  chrome.storage.local.set({ timerVisible: false });
+  send('hideTimer');
+});

--- a/timer.css
+++ b/timer.css
@@ -1,16 +1,13 @@
 #in-browser-timer {
-  position: fixed;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
   background-color: #2ecc71;
   color: #fff;
   padding: 10px 20px;
-  border-radius: 8px;
+  border-radius: 0 0 8px 8px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   font-family: sans-serif;
-  z-index: 2147483647;
   text-align: center;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 #in-browser-timer .ibt-display {

--- a/timer.js
+++ b/timer.js
@@ -42,11 +42,29 @@
   container.appendChild(display);
   container.appendChild(controls);
   container.appendChild(message);
-  document.body.appendChild(container);
+  document.body.insertBefore(container, document.body.firstChild);
 
   let duration = parseInt(select.value, 10);
   let remaining = duration;
   let interval = null;
+
+  chrome.storage?.local.get({ timerVisible: true }, (data) => {
+    if (!data.timerVisible) {
+      container.style.display = 'none';
+    }
+  });
+
+  chrome.runtime?.onMessage.addListener((msg) => {
+    if (msg.action === 'hideTimer') {
+      container.style.display = 'none';
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    } else if (msg.action === 'showTimer') {
+      container.style.display = '';
+    }
+  });
 
   function format(sec) {
     const s = Math.abs(sec);


### PR DESCRIPTION
## Summary
- Embed timer at top of the page so it pushes content downward.
- Allow hiding and showing the timer via popup controls.
- Add storage and message wiring to persist visibility.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f934aee688324a672a85c7a95d26a