### PR TITLE
Hide timer by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A lightweight extension that overlays a configurable countdown timer at the top 
 
 ## Usage
 
+- Open the extension popup and click **Show Timer** to display the timer (hidden by default).
 - Pick a duration from the dropdown and press **Start**.
 - **Stop** pauses the timer, **Reset** returns to the chosen duration.
 - The background color indicates remaining time:

--- a/timer.js
+++ b/timer.js
@@ -4,6 +4,7 @@
 
   const container = document.createElement('div');
   container.id = 'in-browser-timer';
+  container.style.display = 'none'; // hidden by default
 
   // timer display
   const display = document.createElement('div');
@@ -48,9 +49,9 @@
   let remaining = duration;
   let interval = null;
 
-  chrome.storage?.local.get({ timerVisible: true }, (data) => {
-    if (!data.timerVisible) {
-      container.style.display = 'none';
+  chrome.storage?.local.get({ timerVisible: false }, (data) => {
+    if (data.timerVisible) {
+      container.style.display = '';
     }
   });
 


### PR DESCRIPTION
## Summary
- Hide timer overlay on load; it now shows only after the user clicks Show Timer.
- Document the need to click Show Timer in usage instructions.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f97b01be08324913ceaf84695fa4e