### PR TITLE
feat: auto-start timer after reset

### DIFF
--- a/timer.js
+++ b/timer.js
@@ -100,16 +100,18 @@
     update();
   }
 
+  function start() {
+    if (interval) return;
+    interval = setInterval(tick, 1000);
+  }
+
   select.addEventListener('change', () => {
     duration = parseInt(select.value, 10);
     remaining = duration;
     update();
   });
 
-  startBtn.addEventListener('click', () => {
-    if (interval) return;
-    interval = setInterval(tick, 1000);
-  });
+  startBtn.addEventListener('click', start);
 
   stopBtn.addEventListener('click', () => {
     if (interval) {
@@ -123,6 +125,7 @@
     interval = null;
     remaining = duration;
     update();
+    start();
   });
 
   update();


### PR DESCRIPTION
## Summary
- factor out start helper for timer
- automatically start countdown after resetting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f98b438ac832486e3ac52f047084e