### PR TITLE
Reset timer when quick filter trigger clicked

### DIFF
--- a/timer.js
+++ b/timer.js
@@ -105,6 +105,14 @@
     interval = setInterval(tick, 1000);
   }
 
+  function resetTimer() {
+    clearInterval(interval);
+    interval = null;
+    remaining = duration;
+    update();
+    start();
+  }
+
   select.addEventListener('change', () => {
     duration = parseInt(select.value, 10);
     remaining = duration;
@@ -120,12 +128,12 @@
     }
   });
 
-  resetBtn.addEventListener('click', () => {
-    clearInterval(interval);
-    interval = null;
-    remaining = duration;
-    update();
-    start();
+  resetBtn.addEventListener('click', resetTimer);
+
+  document.addEventListener('click', (e) => {
+    if (e.target.closest('#js-work-quickfilters dd a#js-work-quickfilters-trigger')) {
+      resetTimer();
+    }
   });
 
   update();


### PR DESCRIPTION
## Summary
- factor timer reset logic into reusable `resetTimer` function
- restart countdown when Jira quick filters "Show more" trigger is clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f99d9cacc8324981a4b46f0b1cf1f